### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
 		<dependency>
 		  <groupId>io.github.rocsg</groupId>
 		  <artifactId>fijiyama</artifactId>
-		  <version>4.0.10-SNAPSHOT</version>
+		  <version>4.5.0</version>
 		</dependency> 
 	</dependencies>
   	


### PR DESCRIPTION
This package used the version of Fijiyama published on February 2023 (and that was broken in some way, with pixel size issue in blockmatching). I released 4.5.0 and updated the dependency here.